### PR TITLE
Finer control of progression

### DIFF
--- a/steppers/src/main/java/me/drozdzynski/library/steppers/OnChangeStepAction.java
+++ b/steppers/src/main/java/me/drozdzynski/library/steppers/OnChangeStepAction.java
@@ -2,6 +2,6 @@ package me.drozdzynski.library.steppers;
 
 public interface OnChangeStepAction {
 
-    public void onChangeStep(int position, SteppersItem activeStep);
+    public boolean onChangeStep(int position, SteppersItem activeStep);
 
 }

--- a/steppers/src/main/java/me/drozdzynski/library/steppers/OnSkipAction.java
+++ b/steppers/src/main/java/me/drozdzynski/library/steppers/OnSkipAction.java
@@ -1,0 +1,6 @@
+package me.drozdzynski.library.steppers;
+
+public interface OnSkipAction {
+
+    void onSkip(int position);
+}

--- a/steppers/src/main/java/me/drozdzynski/library/steppers/SteppersAdapter.java
+++ b/steppers/src/main/java/me/drozdzynski/library/steppers/SteppersAdapter.java
@@ -123,14 +123,25 @@ public class SteppersAdapter extends RecyclerView.Adapter<SteppersViewHolder> {
             }
         });
 
-        if(config.getOnCancelAction() != null)
-            holder.buttonCancel.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    config.getOnCancelAction().onCancel();
-                }
-            });
-
+        if (steppersItem.isSkippable() && position < getItemCount() -1) {
+            holder.buttonCancel.setText(context.getResources().getString(R.string.step_skip));
+            if (config.getOnSkipAction() != null) {
+                holder.buttonCancel.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        config.getOnSkipAction().onSkip(position);
+                    }
+                });
+            }
+        } else {
+            if (config.getOnCancelAction() != null)
+                holder.buttonCancel.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        config.getOnCancelAction().onCancel();
+                    }
+                });
+        }
 
         LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         //FrameLayout frameLayout = (FrameLayout) inflater.inflate(R.layout.frame_layout, holder.frameLayout, true);
@@ -197,14 +208,26 @@ public class SteppersAdapter extends RecyclerView.Adapter<SteppersViewHolder> {
     }
 
     private void nextStep() {
-        this.removeStep = currentStep - 1 > -1 ? currentStep - 1 : currentStep;
-        this.beforeStep = currentStep;
-        this.currentStep = this.currentStep + 1;
-        notifyItemRangeChanged(removeStep, currentStep);
+        Boolean proceed = true;
 
         if(config.getOnChangeStepAction() != null) {
             SteppersItem steppersItem = items.get(this.currentStep);
-            config.getOnChangeStepAction().onChangeStep(this.currentStep, steppersItem);
+            proceed = config.getOnChangeStepAction().onChangeStep(this.currentStep, steppersItem);
+        }
+
+        if (proceed) {
+            changeToStep(currentStep + 1);
+        }
+    }
+
+    protected void changeToStep (int position) {
+        if (position > currentStep) {
+            this.removeStep = currentStep - 1 > -1 ? currentStep - 1 : currentStep;
+            this.beforeStep = currentStep;
+            this.currentStep = position;
+            notifyItemRangeChanged(removeStep, currentStep);
+        } else {
+            Log.e(TAG, "You can advance through steps, not go back");
         }
     }
 

--- a/steppers/src/main/java/me/drozdzynski/library/steppers/SteppersItem.java
+++ b/steppers/src/main/java/me/drozdzynski/library/steppers/SteppersItem.java
@@ -25,6 +25,7 @@ public class SteppersItem extends Observable {
     private String label;
     private String subLabel;
     private boolean buttonEnable = true;
+    private boolean skippable = false;
     private Fragment fragment;
 
     private boolean displayed = false;
@@ -71,5 +72,13 @@ public class SteppersItem extends Observable {
 
     protected void setDisplayed(boolean displayed) {
         this.displayed = displayed;
+    }
+
+    public boolean isSkippable() {
+        return skippable;
+    }
+
+    public void setSkippable(boolean skippable) {
+        this.skippable = skippable;
     }
 }

--- a/steppers/src/main/java/me/drozdzynski/library/steppers/SteppersView.java
+++ b/steppers/src/main/java/me/drozdzynski/library/steppers/SteppersView.java
@@ -67,6 +67,10 @@ public class SteppersView extends LinearLayout {
         return this;
     }
 
+    public void setActiveItem (int position) {
+        steppersAdapter.changeToStep(position);
+    }
+
     /*public void setPositiveButtonEnable(int position, boolean enable) {
         this.items.get(position).setPositiveButtonEnable(enable);
 
@@ -105,6 +109,7 @@ public class SteppersView extends LinearLayout {
 
         private OnFinishAction onFinishAction;
         private OnCancelAction onCancelAction;
+        private OnSkipAction onSkipAction;
         private OnChangeStepAction onChangeStepAction;
         private FragmentManager fragmentManager;
 
@@ -132,6 +137,12 @@ public class SteppersView extends LinearLayout {
 
         public void setOnChangeStepAction(OnChangeStepAction onChangeStepAction) {
             this.onChangeStepAction = onChangeStepAction;
+        }
+
+        public OnSkipAction getOnSkipAction () { return onSkipAction; }
+
+        public void setOnSkipAction (OnSkipAction onSkipAction) {
+            this.onSkipAction = onSkipAction;
         }
 
         public OnChangeStepAction getOnChangeStepAction() {

--- a/steppers/src/main/res/values/strings.xml
+++ b/steppers/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="step_continue">Continue</string>
     <string name="step_finish">Finish</string>
     <string name="step_cancel">Cancel</string>
+    <string name="step_skip">Skip</string>
 </resources>


### PR DESCRIPTION
I wanted the ability to control the continue button advancing (so that user input could be validated without a button in the fragment) and the ability to let users skip through one or more steps. 

The changes have been made quickly this morning, so probably need reviewing. The sample app has been updated to show the use of these changes. 