### PR TITLE
Migrate to AndroidX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ android:
   components:
     - platform-tool
     - tool
-    - build-tools-26.0.2
-    - android-26
+    - build-tools-28.0.2
+    - android-28
     - extra-android-m2repository
     - extra-google-m2repository
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,13 +3,10 @@
 buildscript {
     repositories {
         jcenter()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.2.0'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,5 @@ POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
 POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=drozdzynski
 POM_DEVELOPER_NAME=Krystian Drożdżyński
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Oct 17 20:14:52 CEST 2017
+#Sat Sep 29 17:25:41 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/steppers-sample/build.gradle
+++ b/steppers-sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 28
+    buildToolsVersion '28.0.2'
 
     defaultConfig {
         applicationId "me.drozdzynski.library.sample.steppers"
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
@@ -20,10 +20,10 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    testCompile 'junit:junit:4.12'
-    compile project(':steppers')
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'com.android.support:design:26.1.0'
-    compile 'com.android.support:support-v4:26.1.0'
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    testImplementation 'junit:junit:4.12'
+    implementation project(':steppers')
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:design:28.0.0'
+    implementation 'com.android.support:support-v4:28.0.0'
 }

--- a/steppers-sample/build.gradle
+++ b/steppers-sample/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     testImplementation 'junit:junit:4.12'
     implementation project(':steppers')
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support:design:28.0.0'
-    implementation 'com.android.support:support-v4:28.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
 }

--- a/steppers-sample/src/main/java/me/drozdzynski/library/sample/steppers/BlankFragment.java
+++ b/steppers-sample/src/main/java/me/drozdzynski/library/sample/steppers/BlankFragment.java
@@ -2,7 +2,7 @@ package me.drozdzynski.library.sample.steppers;
 
 
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
+import androidx.fragment.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/steppers-sample/src/main/java/me/drozdzynski/library/sample/steppers/BlankSecondFragment.java
+++ b/steppers-sample/src/main/java/me/drozdzynski/library/sample/steppers/BlankSecondFragment.java
@@ -2,7 +2,7 @@ package me.drozdzynski.library.sample.steppers;
 
 
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
+import androidx.fragment.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/steppers-sample/src/main/java/me/drozdzynski/library/sample/steppers/MainActivity.java
+++ b/steppers-sample/src/main/java/me/drozdzynski/library/sample/steppers/MainActivity.java
@@ -1,12 +1,11 @@
 package me.drozdzynski.library.sample.steppers;
 
-import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.AlertDialog;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 import android.view.Gravity;
 import android.view.View;
 import android.view.Menu;

--- a/steppers-sample/src/main/res/layout/activity_main.xml
+++ b/steppers-sample/src/main/res/layout/activity_main.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
     android:layout_height="match_parent" android:fitsSystemWindows="true"
     tools:context="me.drozdzynski.library.sample.steppers.MainActivity">
 
-    <android.support.design.widget.AppBarLayout android:layout_width="match_parent"
+    <com.google.android.material.appbar.AppBarLayout android:layout_width="match_parent"
         android:layout_height="wrap_content" android:theme="@style/AppTheme.AppBarOverlay">
 
-        <android.support.v7.widget.Toolbar android:id="@+id/toolbar"
+        <androidx.appcompat.widget.Toolbar android:id="@+id/toolbar"
             android:layout_width="match_parent" android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary" app:popupTheme="@style/AppTheme.PopupOverlay" />
 
-    </android.support.design.widget.AppBarLayout>
+    </com.google.android.material.appbar.AppBarLayout>
 
     <include layout="@layout/content_main" />
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/steppers/build.gradle
+++ b/steppers/build.gradle
@@ -2,20 +2,20 @@ apply plugin: 'com.android.library'
 apply from: '../gradle/maven_push.gradle'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 28
+    buildToolsVersion '28.0.2'
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 9
         versionName "1.0.0"
     }
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'com.android.support:recyclerview-v7:26.1.0'
-    compile 'com.android.support:support-v4:26.1.0'
+    testImplementation 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:recyclerview-v7:28.0.0'
+    implementation 'com.android.support:support-v4:28.0.0'
 }

--- a/steppers/build.gradle
+++ b/steppers/build.gradle
@@ -15,7 +15,7 @@ android {
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support:recyclerview-v7:28.0.0'
-    implementation 'com.android.support:support-v4:28.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.recyclerview:recyclerview:1.0.0'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
 }

--- a/steppers/src/main/java/me/drozdzynski/library/steppers/RoundedView.java
+++ b/steppers/src/main/java/me/drozdzynski/library/steppers/RoundedView.java
@@ -27,7 +27,7 @@ import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
-import android.support.v4.content.ContextCompat;
+import androidx.core.content.ContextCompat;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.view.View;

--- a/steppers/src/main/java/me/drozdzynski/library/steppers/SteppersAdapter.java
+++ b/steppers/src/main/java/me/drozdzynski/library/steppers/SteppersAdapter.java
@@ -17,11 +17,11 @@
 package me.drozdzynski.library.steppers;
 
 import android.content.Context;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
-import android.support.v4.app.FragmentTransaction;
-import android.support.v4.content.ContextCompat;
-import android.support.v7.widget.RecyclerView;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+import androidx.fragment.app.FragmentTransaction;
+import androidx.core.content.ContextCompat;
+import androidx.recyclerview.widget.RecyclerView;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;

--- a/steppers/src/main/java/me/drozdzynski/library/steppers/SteppersItem.java
+++ b/steppers/src/main/java/me/drozdzynski/library/steppers/SteppersItem.java
@@ -16,7 +16,7 @@
 
 package me.drozdzynski.library.steppers;
 
-import android.support.v4.app.Fragment;
+import androidx.fragment.app.Fragment;
 
 import java.util.Observable;
 

--- a/steppers/src/main/java/me/drozdzynski/library/steppers/SteppersView.java
+++ b/steppers/src/main/java/me/drozdzynski/library/steppers/SteppersView.java
@@ -19,9 +19,9 @@ package me.drozdzynski.library.steppers;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
-import android.support.v4.app.FragmentManager;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
+import androidx.fragment.app.FragmentManager;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
@@ -32,7 +32,6 @@ import java.util.List;
 import me.drozdzynski.library.steppers.interfaces.OnCancelAction;
 import me.drozdzynski.library.steppers.interfaces.OnChangeStepAction;
 import me.drozdzynski.library.steppers.interfaces.OnFinishAction;
-import me.drozdzynski.library.steppers.interfaces.OnSkipStepAction;
 
 public class SteppersView extends LinearLayout {
 

--- a/steppers/src/main/java/me/drozdzynski/library/steppers/SteppersViewHolder.java
+++ b/steppers/src/main/java/me/drozdzynski/library/steppers/SteppersViewHolder.java
@@ -16,8 +16,8 @@
 
 package me.drozdzynski.library.steppers;
 
-import android.support.v4.app.Fragment;
-import android.support.v7.widget.RecyclerView;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.RecyclerView;
 import android.view.View;
 import android.widget.Button;
 import android.widget.FrameLayout;

--- a/steppers/src/main/res/layout/steppers_recycle.xml
+++ b/steppers/src/main/res/layout/steppers_recycle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.RecyclerView
+<androidx.recyclerview.widget.RecyclerView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-</android.support.v7.widget.RecyclerView>
+</androidx.recyclerview.widget.RecyclerView>


### PR DESCRIPTION
As detailed [here](https://developer.android.com/topic/libraries/support-library/androidx-overview), the support libraries are being moved to a new package structure. No significant changes are needed other than just refactoring a bunch of stuff. I updated the target sdk to 28 as well.